### PR TITLE
SCTP transport support

### DIFF
--- a/src/ersip.erl
+++ b/src/ersip.erl
@@ -20,7 +20,7 @@
               nexthop/0
              ]).
 
--type transport_atom() :: udp | tcp | tls | ws | wss.
+-type transport_atom() :: udp | tcp | tls | ws | wss | sctp.
 -type connection_id()  :: term().
 
 -type sip_options() :: #{sip_t1 => pos_integer(),

--- a/src/transport/ersip_conn.erl
+++ b/src/transport/ersip_conn.erl
@@ -48,7 +48,7 @@
       Options      :: options().
 new(LocalAddr, LocalPort, RemoteAddr, RemotePort, SIPTransport, Options) ->
     ParserOptions = maps:get(parser, Options, #{}),
-    IsDgram       = ersip_transport:is_datagram(SIPTransport),
+    IsDgram       = ersip_transport:is_message_oriented(SIPTransport),
     #sip_conn{
        local_addr  = {ersip_host:make(LocalAddr),  LocalPort},
        remote_addr = {ersip_host:make(RemoteAddr), RemotePort},

--- a/src/uri/ersip_transport.erl
+++ b/src/uri/ersip_transport.erl
@@ -103,11 +103,11 @@ is_datagram({transport, ws}) ->
     true;
 is_datagram({transport, wss}) ->
     true;
+is_datagram({transport, sctp}) ->
+    true;
 is_datagram({transport, tls}) ->
     false;
 is_datagram({transport, tcp}) ->
-    false;
-is_datagram({transport, sctp}) ->
     false;
 is_datagram({other_transport, Binary}) when is_binary(Binary) ->
     error({error, {unknown_transport_type, Binary}}).

--- a/src/uri/ersip_transport.erl
+++ b/src/uri/ersip_transport.erl
@@ -12,7 +12,7 @@
          make_by_uri/1,
          tcp/0, tls/0, udp/0,
          is_known_transport/1,
-         is_datagram/1,
+         is_message_oriented/1,
          is_tls/1,
          is_reliable/1,
          parse/1,
@@ -96,20 +96,20 @@ is_known_transport({transport, _}) ->
 is_known_transport({other_transport, _}) ->
     false.
 
--spec is_datagram(known_transport()) -> boolean().
-is_datagram({transport, udp}) ->
+-spec is_message_oriented(known_transport()) -> boolean().
+is_message_oriented({transport, udp}) ->
     true;
-is_datagram({transport, ws}) ->
+is_message_oriented({transport, ws}) ->
     true;
-is_datagram({transport, wss}) ->
+is_message_oriented({transport, wss}) ->
     true;
-is_datagram({transport, sctp}) ->
+is_message_oriented({transport, sctp}) ->
     true;
-is_datagram({transport, tls}) ->
+is_message_oriented({transport, tls}) ->
     false;
-is_datagram({transport, tcp}) ->
+is_message_oriented({transport, tcp}) ->
     false;
-is_datagram({other_transport, Binary}) when is_binary(Binary) ->
+is_message_oriented({other_transport, Binary}) when is_binary(Binary) ->
     error({error, {unknown_transport_type, Binary}}).
 
 -spec is_tls(known_transport()) -> boolean().

--- a/src/uri/ersip_transport.erl
+++ b/src/uri/ersip_transport.erl
@@ -30,7 +30,7 @@
 %%% Types
 %%%===================================================================
 
--type transport_atom() :: udp | tcp | tls | ws | wss.
+-type transport_atom() :: udp | tcp | tls | ws | wss | sctp.
 -type transport() :: known_transport()
                    | other_transport().
 -type known_transport() :: {transport, transport_atom()}.
@@ -85,7 +85,7 @@ parse(V) when is_binary(V) ->
         T ->
             {ok, T}
     end;
-parse(V) when V =:= tcp; V =:= udp; V =:= tls; V =:= wss; V =:= ws ->
+parse(V) when V =:= tcp; V =:= udp; V =:= tls; V =:= wss; V =:= ws; V =:= sctp ->
     {ok, {transport, V}};
 parse(V) when is_atom(V) ->
     {error, {bad_transport_atom, V}}.
@@ -107,6 +107,8 @@ is_datagram({transport, tls}) ->
     false;
 is_datagram({transport, tcp}) ->
     false;
+is_datagram({transport, sctp}) ->
+    false;
 is_datagram({other_transport, Binary}) when is_binary(Binary) ->
     error({error, {unknown_transport_type, Binary}}).
 
@@ -114,6 +116,8 @@ is_datagram({other_transport, Binary}) when is_binary(Binary) ->
 is_tls({transport, udp}) ->
     false;
 is_tls({transport, tcp}) ->
+    false;
+is_tls({transport, sctp}) ->
     false;
 is_tls({transport, ws}) ->
     false;
@@ -135,6 +139,8 @@ is_reliable({transport, tls}) ->
     true;
 is_reliable({transport, tcp}) ->
     true;
+is_reliable({transport, sctp}) ->
+    true;
 is_reliable({other_transport, Binary}) when is_binary(Binary) ->
     error({error, {unknown_transport_type, Binary}}).
 
@@ -152,6 +158,8 @@ default_port({transport, tcp}) ->
     5060; %% RFC 3261 19.1.2
 default_port({transport, udp}) ->
     5060; %% RFC 3261 19.1.2
+default_port({transport, sctp}) ->
+    5060; %% RFC 3261 19.1.2
 default_port({transport, tls}) ->
     5061; %% RFC 3261 19.1.2
 default_port({transport, ws}) ->
@@ -166,6 +174,8 @@ assemble_upper({transport, udp}) ->
     <<"UDP">>;
 assemble_upper({transport, tcp}) ->
     <<"TCP">>;
+assemble_upper({transport, sctp}) ->
+    <<"SCTP">>;
 assemble_upper({transport, tls}) ->
     <<"TLS">>;
 assemble_upper({transport, ws}) ->
@@ -184,6 +194,8 @@ assemble_bin({transport, udp}) ->
     <<"udp">>;
 assemble_bin({transport, tcp}) ->
     <<"tcp">>;
+assemble_bin({transport, sctp}) ->
+    <<"sctp">>;
 assemble_bin({transport, tls}) ->
     <<"tls">>;
 assemble_bin({transport, ws}) ->
@@ -200,6 +212,7 @@ assemble_bin({other_transport, Binary}) ->
 -spec parse_bin(binary()) -> transport() | {error, {einval, transport}}.
 parse_bin(V) ->
     case ersip_bin:to_lower(V) of
+        <<"sctp">> -> {transport, sctp};
         <<"tcp">> -> {transport, tcp};
         <<"udp">> -> {transport, udp};
         <<"tls">> -> {transport, tls};

--- a/test/uri/ersip_transport_test.erl
+++ b/test/uri/ersip_transport_test.erl
@@ -32,14 +32,14 @@ default_port_test() ->
     CustomTransport = make_transport(<<"unknowntranport">>),
     ?assertEqual({default_port, CustomTransport}, ersip_transport:default_port(CustomTransport)).
 
-is_datagram_test() ->
-    ?assertEqual(true,  ersip_transport:is_datagram(make_transport(udp))),
-    ?assertEqual(true,  ersip_transport:is_datagram(make_transport(ws))),
-    ?assertEqual(true,  ersip_transport:is_datagram(make_transport(wss))),
-    ?assertEqual(true,  ersip_transport:is_datagram(make_transport(sctp))),
-    ?assertEqual(false, ersip_transport:is_datagram(make_transport(tls))),
-    ?assertEqual(false, ersip_transport:is_datagram(make_transport(tcp))),
-    ?assertError({error, _}, ersip_transport:is_datagram(make_transport(<<"unknowntranport">>))).
+is_message_oriented_test() ->
+    ?assertEqual(true,  ersip_transport:is_message_oriented(make_transport(udp))),
+    ?assertEqual(true,  ersip_transport:is_message_oriented(make_transport(ws))),
+    ?assertEqual(true,  ersip_transport:is_message_oriented(make_transport(wss))),
+    ?assertEqual(true,  ersip_transport:is_message_oriented(make_transport(sctp))),
+    ?assertEqual(false, ersip_transport:is_message_oriented(make_transport(tls))),
+    ?assertEqual(false, ersip_transport:is_message_oriented(make_transport(tcp))),
+    ?assertError({error, _}, ersip_transport:is_message_oriented(make_transport(<<"unknowntranport">>))).
 
 is_tls_test() ->
     ?assertEqual(false, ersip_transport:is_tls(make_transport(udp))),

--- a/test/uri/ersip_transport_test.erl
+++ b/test/uri/ersip_transport_test.erl
@@ -36,9 +36,9 @@ is_datagram_test() ->
     ?assertEqual(true,  ersip_transport:is_datagram(make_transport(udp))),
     ?assertEqual(true,  ersip_transport:is_datagram(make_transport(ws))),
     ?assertEqual(true,  ersip_transport:is_datagram(make_transport(wss))),
+    ?assertEqual(true,  ersip_transport:is_datagram(make_transport(sctp))),
     ?assertEqual(false, ersip_transport:is_datagram(make_transport(tls))),
     ?assertEqual(false, ersip_transport:is_datagram(make_transport(tcp))),
-    ?assertEqual(false, ersip_transport:is_datagram(make_transport(sctp))),
     ?assertError({error, _}, ersip_transport:is_datagram(make_transport(<<"unknowntranport">>))).
 
 is_tls_test() ->

--- a/test/uri/ersip_transport_test.erl
+++ b/test/uri/ersip_transport_test.erl
@@ -25,6 +25,7 @@ parse_port_number_test() ->
 default_port_test() ->
     ?assertEqual(5060, ersip_transport:default_port(make_transport(udp))),
     ?assertEqual(5060, ersip_transport:default_port(make_transport(tcp))),
+    ?assertEqual(5060,  ersip_transport:default_port(make_transport(sctp))),
     ?assertEqual(5061, ersip_transport:default_port(make_transport(tls))),
     ?assertEqual(80,   ersip_transport:default_port(make_transport(ws))),
     ?assertEqual(443,  ersip_transport:default_port(make_transport(wss))),
@@ -37,6 +38,7 @@ is_datagram_test() ->
     ?assertEqual(true,  ersip_transport:is_datagram(make_transport(wss))),
     ?assertEqual(false, ersip_transport:is_datagram(make_transport(tls))),
     ?assertEqual(false, ersip_transport:is_datagram(make_transport(tcp))),
+    ?assertEqual(false, ersip_transport:is_datagram(make_transport(sctp))),
     ?assertError({error, _}, ersip_transport:is_datagram(make_transport(<<"unknowntranport">>))).
 
 is_tls_test() ->
@@ -45,6 +47,7 @@ is_tls_test() ->
     ?assertEqual(true,  ersip_transport:is_tls(make_transport(wss))),
     ?assertEqual(true,  ersip_transport:is_tls(make_transport(tls))),
     ?assertEqual(false, ersip_transport:is_tls(make_transport(tcp))),
+    ?assertEqual(false, ersip_transport:is_tls(make_transport(sctp))),
     ?assertError({error, _}, ersip_transport:is_tls(make_transport(<<"unknowntranport">>))).
 
 is_reliable_test() ->
@@ -53,6 +56,7 @@ is_reliable_test() ->
     ?assertEqual(true,   ersip_transport:is_reliable(make_transport(wss))),
     ?assertEqual(true,   ersip_transport:is_reliable(make_transport(tls))),
     ?assertEqual(true,   ersip_transport:is_reliable(make_transport(tcp))),
+    ?assertEqual(true,   ersip_transport:is_reliable(make_transport(sctp))),
     ?assertError({error, _}, ersip_transport:is_reliable(make_transport(<<"unknowntranport">>))).
 
 
@@ -62,6 +66,7 @@ assemble_test() ->
     ?assertEqual(<<"WSS">>, ersip_transport:assemble_upper(make_transport(wss))),
     ?assertEqual(<<"TLS">>, ersip_transport:assemble_upper(make_transport(tls))),
     ?assertEqual(<<"TCP">>, ersip_transport:assemble_upper(make_transport(tcp))),
+    ?assertEqual(<<"SCTP">>, ersip_transport:assemble_upper(make_transport(sctp))),
     ?assertEqual(<<"SOME">>, ersip_transport:assemble_upper(make_transport(<<"some">>))),
 
     ?assertEqual(<<"udp">>, ersip_transport:assemble(make_transport(udp))),
@@ -69,6 +74,7 @@ assemble_test() ->
     ?assertEqual(<<"wss">>, ersip_transport:assemble(make_transport(wss))),
     ?assertEqual(<<"tls">>, ersip_transport:assemble(make_transport(tls))),
     ?assertEqual(<<"tcp">>, ersip_transport:assemble(make_transport(tcp))),
+    ?assertEqual(<<"sctp">>, ersip_transport:assemble(make_transport(sctp))),
     ?assertEqual(<<"some">>, ersip_transport:assemble(make_transport(<<"Some">>))).
 
 make_test() ->
@@ -80,6 +86,7 @@ make_by_uri_test() ->
     ?assertEqual({transport, ws},  ersip_transport:make_by_uri(ersip_uri:make(<<"sip:a@b;transport=ws">>))),
     ?assertEqual({transport, udp}, ersip_transport:make_by_uri(ersip_uri:make(<<"sip:a@b;transport=udp">>))),
     ?assertEqual({transport, tcp}, ersip_transport:make_by_uri(ersip_uri:make(<<"sip:a@b;transport=tcp">>))),
+    ?assertEqual({transport, sctp}, ersip_transport:make_by_uri(ersip_uri:make(<<"sip:a@b;transport=sctp">>))),
     ?assertEqual(make_transport(<<"some">>), ersip_transport:make_by_uri(ersip_uri:make(<<"sip:a@b;transport=some">>))),
     ok.
 

--- a/test/uri/ersip_uri_test.erl
+++ b/test/uri/ersip_uri_test.erl
@@ -116,6 +116,11 @@ uri_test() ->
                            host = {hostname, <<"b">>},
                            params = #{transport := {transport, tcp}}}}},
        ersip_uri:parse(<<"sip:b;transport=tcp">>)),
+   ?assertMatch(
+       {ok, #uri{data = #sip_uri_data{
+                           host = {hostname, <<"b">>},
+                           params = #{transport := {transport, sctp}}}}},
+       ersip_uri:parse(<<"sip:b;transport=sctp">>)),
     ?assertMatch(
        {ok, #uri{data = #sip_uri_data{
                            host = {hostname, <<"b">>},


### PR DESCRIPTION
Hello!

Thank you for your work. We use your library in our project and it helps us a lot!
 
But for some of connections we have to use SCTP protocol. This seems like a common requirement in telecomunication industry. 

This pull request simply adds SCTP related "constants". No real logic changes were neccesary. SCTP is simply a "reliable" transport in SIP terms (as far as we understand).