### PR TITLE
Serializable state for non-INVITE transactions

### DIFF
--- a/src/transaction/ersip_trans_client.erl
+++ b/src/transaction/ersip_trans_client.erl
@@ -15,6 +15,13 @@
          clear_reason/1
         ]).
 
+%% Internal export:
+-export(['Trying'/2,
+         'Proceeding'/2,
+         'Completed'/2,
+         'Terminated'/2
+        ]).
+
 -export_type([trans_client/0,
               result/0,
               clear_reason/0

--- a/src/transaction/ersip_trans_server.erl
+++ b/src/transaction/ersip_trans_server.erl
@@ -12,6 +12,14 @@
 
 -export([new/3,
          event/2]).
+
+%% Internal export:
+-export(['Trying'/2,
+         'Proceeding'/2,
+         'Completed'/2,
+         'Terminated'/2
+]).
+
 -export_type([trans_server/0
              ]).
 
@@ -20,10 +28,6 @@
 %%%===================================================================
 
 -type result()  :: {trans_server(), [ersip_trans_se:effect()]}.
--type event()   :: enter
-                 | retransmit
-                 | {send_resp, ersip_status:response_type(), Response :: term()}
-                 | {timer, timer_j}.
 -type request()  :: term().
 -type response() :: term().
 

--- a/test/transaction/ersip_trans_inv_client_test.erl
+++ b/test/transaction/ersip_trans_inv_client_test.erl
@@ -251,6 +251,54 @@ trans_expire_set_test() ->
     [{TransExpire, _TransactionTimer1}] = lists:sort(proplists:get_all_values(set_timer, SideEffects1)),
     ok.
 
+to_map_test() ->
+   {Trans0, _} = ersip_trans_inv_client:new(unreliable, invite_req(), #{}),
+   Expected0 = #{state => 'Calling',
+                 transport => unreliable,
+                 options => #{sip_t1 => 500},
+                 request => element(5, Trans0),
+                 clear_reason => normal,
+                 timer_a_timeout => 500,
+                 last_ack => undefined
+                },
+   ?assertEqual(Expected0, ersip_trans_inv_client:to_map(Trans0)),
+   ?assertEqual(Trans0, ersip_trans_inv_client:from_map(Expected0)),
+
+   {Trans1, _} = ersip_trans_inv_client:event({received, trying()}, Trans0),
+   Expected1 = #{state => 'Proceeding',
+                 transport => unreliable,
+                 options => #{sip_t1 => 500},
+                 request => element(5, Trans1),
+                 clear_reason => normal,
+                 timer_a_timeout => 500,
+                 last_ack => undefined
+                },
+   ?assertEqual(Expected1, ersip_trans_inv_client:to_map(Trans1)),
+   ?assertEqual(Trans1, ersip_trans_inv_client:from_map(Expected1)),
+
+    {Trans2, _} = ersip_trans_inv_client:event({received, ok200()}, Trans1),
+    Expected2 = #{state => 'Accepted',
+                  transport => unreliable,
+                  options => #{sip_t1 => 500},
+                  request => element(5, Trans2),
+                  clear_reason => normal,
+                  timer_a_timeout => 500,
+                  last_ack => undefined
+                 },
+    ?assertEqual(Expected2, ersip_trans_inv_client:to_map(Trans2)),
+    ?assertEqual(Trans2, ersip_trans_inv_client:from_map(Expected2)),
+
+    {Trans3, _} =  ersip_trans_inv_client:event({timer, timer_m}, Trans2),
+    Expected3 = #{state => 'Terminated',
+                  transport => unreliable,
+                  options => #{sip_t1 => 500},
+                  request => element(5, Trans3),
+                  clear_reason => normal,
+                  timer_a_timeout => 500,
+                  last_ack => undefined
+                 },
+    ?assertEqual(Expected3, ersip_trans_inv_client:to_map(Trans3)),
+    ?assertEqual(Trans3, ersip_trans_inv_client:from_map(Expected3)).
 
 %%%===================================================================
 %%% Helpers

--- a/test/transaction/ersip_trans_inv_server_test.erl
+++ b/test/transaction/ersip_trans_inv_server_test.erl
@@ -247,6 +247,40 @@ error_handling_test() ->
 
     ok.
 
+to_map_test() ->
+    {Trans0, _} = ersip_trans_inv_server:new(unreliable, invite(), #{}),
+    Expected0 = #{state => 'Proceeding',
+                  transport => unreliable,
+                  options => #{sip_t1 => 500,sip_t2 => 4000,sip_t4 => 5000},
+                  last_resp => element(5, Trans0),
+                  timer_g_timeout => 500,
+                  clear_reason => normal
+                 },
+    ?assertEqual(Expected0, ersip_trans_inv_server:to_map(Trans0)),
+    ?assertEqual(Trans0, ersip_trans_inv_server:from_map(Expected0)),
+
+    {Trans1, _} = ersip_trans_inv_server:event({send, ok200()}, Trans0),
+    Expected1 = #{state => 'Accepted',
+                  transport => unreliable,
+                  options => #{sip_t1 => 500,sip_t2 => 4000,sip_t4 => 5000},
+                  last_resp => element(5, Trans1),
+                  timer_g_timeout => 500,
+                  clear_reason => normal
+                 },
+    ?assertEqual(Expected1, ersip_trans_inv_server:to_map(Trans1)),
+    ?assertEqual(Trans1, ersip_trans_inv_server:from_map(Expected1)),
+
+    {Trans2, _} = ersip_trans_inv_server:event({timer, timer_l}, Trans1),
+    Expected2 = #{state => 'Terminated',
+                  transport => unreliable,
+                  options => #{sip_t1 => 500,sip_t2 => 4000,sip_t4 => 5000},
+                  last_resp => element(5, Trans2),
+                  timer_g_timeout => 500,
+                  clear_reason => normal
+                 },
+    ?assertEqual(Expected2, ersip_trans_inv_server:to_map(Trans2)),
+    ?assertEqual(Trans2, ersip_trans_inv_server:from_map(Expected2)).
+
 %%%===================================================================
 %%% Helpers
 %%%===================================================================

--- a/test/transaction/ersip_trans_server_test.erl
+++ b/test/transaction/ersip_trans_server_test.erl
@@ -83,6 +83,43 @@ uas_unreliable_test() ->
     %% Transaction is cleared
     ?assertMatch(normal, maps:get(clear_trans, SideEffectsMap_1_2)).
 
+to_map_test() ->
+    {ServerTrans0, _} = ersip_trans_server:new(unreliable, request(), #{}),
+    Expected0 = #{state => 'Trying',
+                  last_resp => undefined,
+                  transport => unreliable,
+                  options => #{sip_t1 => 500}
+                 },
+    ?assertEqual(Expected0, ersip_trans_server:to_map(ServerTrans0)),
+    ?assertEqual(ServerTrans0, ersip_trans_server:from_map(Expected0)),
+
+    {ServerTrans1, _} = ersip_trans_server:event(prov_response_event(), ServerTrans0),
+    Expected1 = #{state => 'Proceeding',
+                  last_resp => prov_response(),
+                  transport => unreliable,
+                  options => #{sip_t1 => 500}
+                 },
+    ?assertEqual(Expected1, ersip_trans_server:to_map(ServerTrans1)),
+    ?assertEqual(ServerTrans1, ersip_trans_server:from_map(Expected1)),
+
+    {ServerTrans2, _} = ersip_trans_server:event(final_response_event(), ServerTrans1),
+    Expected2 = #{state => 'Completed',
+                  last_resp => final_response(),
+                  transport => unreliable,
+                  options => #{sip_t1 => 500}
+                 },
+    ?assertEqual(Expected2, ersip_trans_server:to_map(ServerTrans2)),
+    ?assertEqual(ServerTrans2, ersip_trans_server:from_map(Expected2)),
+
+    {ServerTrans3, _} = ersip_trans_server:event({timer, timer_j}, ServerTrans2),
+    Expected3 = #{state => 'Terminated',
+                  last_resp => final_response(),
+                  transport => unreliable,
+                  options => #{sip_t1 => 500}
+                 },
+    ?assertEqual(Expected3, ersip_trans_server:to_map(ServerTrans3)),
+    ?assertEqual(ServerTrans3, ersip_trans_server:from_map(Expected3)).
+
 %%%===================================================================
 %%% Helpers
 %%%===================================================================


### PR DESCRIPTION
Non-INVITE client and server transactions were refactored similarly to INVITE transactions.