### PR TITLE
Fix take first via when Via header has multiple values (multiple via) in one line separated by commas

### DIFF
--- a/src/message/ersip_hdr.erl
+++ b/src/message/ersip_hdr.erl
@@ -87,8 +87,8 @@ is_empty(#header{}) ->
 add_value(Value, #header{values = V} = Hdr) ->
     Hdr#header{values = V ++ [Value]}.
 
-%% @doc Append list of values to headr's list of values.
--spec add_values(Value :: value(), header()) -> header().
+%% @doc Append list of values to header's list of values.
+-spec add_values(Values :: [value()], header()) -> header().
 add_values(Values, #header{} = Hdr) ->
     lists:foldl(fun add_value/2,
                 Hdr,

--- a/src/uri/ersip_uri.erl
+++ b/src/uri/ersip_uri.erl
@@ -193,7 +193,9 @@ assemble_bin(#uri{} = U) ->
 
 -spec params(uri()) -> uri_params().
 params(#uri{data = #sip_uri_data{params = Params}}) ->
-    Params.
+    Params;
+params(_) ->
+    #{}.
 
 -spec raw_params(uri()) -> [{binary(), binary()} | binary()].
 raw_params(#uri{data = #sip_uri_data{params = Params}}) ->

--- a/test/ersip_response_test.erl
+++ b/test/ersip_response_test.erl
@@ -97,6 +97,6 @@ make_target(HostBin, Port, Transport, TTL) ->
     {ersip_host:make(HostBin), Port, ersip_transport:make(Transport), #{ttl => TTL}}.
 
 target(ViaBin) ->
-    {ok, Via} = ersip_hdr_via:parse(ViaBin),
+    {ok, [Via|_]} = ersip_hdr_via:parse(ViaBin),
     ersip_response:target(Via).
 

--- a/test/message/ersip_hdr_via_test.erl
+++ b/test/message/ersip_hdr_via_test.erl
@@ -49,7 +49,7 @@ topmost_via_ipport_test() ->
     ?assertEqual(5090, Port).
 
 check_params_test() ->
-    {ok, Via} = ersip_hdr_via:parse((<<"SIP/2.0/TCP 192.168.1.1:5090;branch=z9hG4bK77ef4c2312983.1;rport;x=1;some">>)),
+    {ok, [Via]} = ersip_hdr_via:parse((<<"SIP/2.0/TCP 192.168.1.1:5090;branch=z9hG4bK77ef4c2312983.1;rport;x=1;some">>)),
     ?assertEqual({ok, ersip_branch:make(<<"z9hG4bK77ef4c2312983.1">>)}, ersip_hdr_via:branch(Via)),
     ?assertEqual({ok, true}, ersip_hdr_via:rport(Via)),
     ?assertEqual({ok, <<"1">>}, ersip_hdr_via:raw_param(<<"x">>, Via)),


### PR DESCRIPTION
1) Fix take first via when Via header has multiple values (multiple via) in one line separated by commas
Please note that in this pull request specification of ersip_hdr_via:parse has been changed, now it returns a list, because one VIA line may contain multiple values.
2)  a minor correction of spec.
3) a minor fix to proxy tel RURI without error