### PR TITLE
Parse SDP media attributes from BFCP (RFC8856)

### DIFF
--- a/src/sdp/media/ersip_sdp_bfcp_floorctrl.erl
+++ b/src/sdp/media/ersip_sdp_bfcp_floorctrl.erl
@@ -1,0 +1,124 @@
+%%
+%% Copyright (c) 2021 Dmitry Poroh
+%% All rights reserved.
+%% Distributed under the terms of the MIT License. See the LICENSE file.
+%%
+%% SDP media BFCP 'floorctrl' attribute
+%%
+
+-module(ersip_sdp_bfcp_floorctrl).
+
+-export([new/2,
+         client/1,
+         server/1,
+         set_client/2,
+         set_server/2,
+         parse/1,
+         assemble/1,
+         assemble_bin/1
+        ]).
+
+-export_type([bfcp_floorctrl/0]).
+
+%%%===================================================================
+%%% Types
+%%%===================================================================
+-record(bfcp_floorctrl, {client = false :: boolean(),
+                         server = false :: boolean()}).
+
+-type bfcp_floorctrl() :: #bfcp_floorctrl{}.
+
+-type parse_result()  :: parse_result(bfcp_floorctrl()).
+-type parse_result(T) :: ersip_parser_aux:parse_result(T).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+-spec new(boolean(), boolean()) -> bfcp_floorctrl().
+new(C, S) ->
+    #bfcp_floorctrl{client = C, server = S}.
+
+-spec client(bfcp_floorctrl()) -> boolean().
+client(#bfcp_floorctrl{client = C}) ->
+    C.
+
+-spec server(bfcp_floorctrl()) -> boolean().
+server(#bfcp_floorctrl{server = S}) ->
+    S.
+
+-spec set_client(boolean(), bfcp_floorctrl()) -> bfcp_floorctrl().
+set_client(C, #bfcp_floorctrl{} = BF) ->
+    BF#bfcp_floorctrl{client = C}.
+
+-spec set_server(boolean(), bfcp_floorctrl()) -> bfcp_floorctrl().
+set_server(S, #bfcp_floorctrl{} = BF) ->
+    BF#bfcp_floorctrl{server = S}.
+
+-spec parse(binary()) -> parse_result().
+parse(Bin) ->
+    do_parse_bfcp_floorctrl(Bin).
+
+-spec assemble(bfcp_floorctrl()) -> iolist().
+assemble(BF) ->
+    assemble_bfcp_floorctrl(BF).
+
+-spec assemble_bin(bfcp_floorctrl()) -> binary().
+assemble_bin(BF) ->
+    iolist_to_binary(assemble(BF)).
+
+%%%===================================================================
+%%% Internal implementation
+%%%===================================================================
+-define(sp, " ").
+
+%% https://tools.ietf.org/rfc/rfc8856.html#name-sdp-floorctrl-attribute
+%%
+%% floor-control = role *(SP role)
+%% role = "c-only" / "s-only" / "c-s"
+%%
+-spec do_parse_bfcp_floorctrl(binary()) -> parse_result().
+do_parse_bfcp_floorctrl(Bin) ->
+    Tokens = binary:split(Bin, <<?sp>>, [global]),
+    case parse_roles(Tokens) of
+        {ok, _BF, _Rest} = OK ->
+            OK;
+        {error, Reason} ->
+            {error, {invalid_bfcp_floorctrl, Reason}}
+    end.
+
+-spec assemble_bfcp_floorctrl(bfcp_floorctrl()) -> iolist().
+assemble_bfcp_floorctrl(#bfcp_floorctrl{
+                          server = S,
+                          client = C}) ->
+    lists:join(?sp, assemble_server(S) ++ assemble_client(C)).
+
+-spec parse_roles([binary()]) -> parse_result().
+parse_roles(Tokens) ->
+    parse_roles(Tokens, #bfcp_floorctrl{}).
+
+-spec parse_roles([binary()], bfcp_floorctrl()) -> parse_result().
+parse_roles([<<"c-s">>|Tokens], BF) ->
+    BF1 = BF#bfcp_floorctrl{
+            client = true,
+            server = true},
+    parse_roles(Tokens, BF1);
+parse_roles([<<"s-only">>|Tokens], BF) ->
+    BF1 = BF#bfcp_floorctrl{server = true},
+    parse_roles(Tokens, BF1);
+parse_roles([<<"c-only">>|Tokens], BF) ->
+    BF1 = BF#bfcp_floorctrl{client = true},
+    parse_roles(Tokens, BF1);
+parse_roles([Junk|_], _) ->
+    {error, {invalid_role, Junk}};
+parse_roles([], BF) ->
+    {ok, BF, <<>>}.
+
+assemble_server(false) ->
+    [];
+assemble_server(true) ->
+    [<<"s-only">>].
+
+assemble_client(false) ->
+    [];
+assemble_client(true) ->
+    [<<"c-only">>].

--- a/src/sdp/media/ersip_sdp_bfcp_floorid.erl
+++ b/src/sdp/media/ersip_sdp_bfcp_floorid.erl
@@ -1,0 +1,124 @@
+%%
+%% Copyright (c) 2021 Dmitry Poroh
+%% All rights reserved.
+%% Distributed under the terms of the MIT License. See the LICENSE file.
+%%
+%% SDP media BFCP 'floorid' attribute
+%%
+
+-module(ersip_sdp_bfcp_floorid).
+
+-export([new/2,
+         id/1,
+         streams/1,
+         set_id/2,
+         set_streams/2,
+         parse/1,
+         assemble/1,
+         assemble_bin/1
+        ]).
+
+-export_type([bfcp_floorid/0]).
+-export_type([streams/0]).
+
+-define(is_uint16(I), (is_integer(I) andalso I >= 0 andalso I =< 65535)).
+
+%%%===================================================================
+%%% Types
+%%%===================================================================
+-record(bfcp_floorid, {id :: non_neg_integer(),
+                       streams :: streams()
+                      }).
+
+-type bfcp_floorid() :: #bfcp_floorid{}.
+-type streams() :: [binary(), ...].
+
+-type parse_result()  :: ersip_parser_aux:parse_result(bfcp_floorid()).
+-type parse_result(T) :: ersip_parser_aux:parse_result(T).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+-spec new(non_neg_integer(), streams()) -> bfcp_floorid().
+new(I, [_|_] = Streams) when ?is_uint16(I) ->
+    #bfcp_floorid{id = I, streams = Streams}.
+
+-spec id(bfcp_floorid()) -> non_neg_integer().
+id(#bfcp_floorid{id = I}) ->
+    I.
+
+-spec streams(bfcp_floorid()) -> streams().
+streams(#bfcp_floorid{streams = Ss}) ->
+    Ss.
+
+-spec set_id(non_neg_integer(), bfcp_floorid()) -> bfcp_floorid().
+set_id(I, #bfcp_floorid{} = BF) when ?is_uint16(I) ->
+    BF#bfcp_floorid{id = I}.
+
+-spec set_streams(streams(), bfcp_floorid()) -> bfcp_floorid().
+set_streams([_|_] = Ss, #bfcp_floorid{} = BF) ->
+    BF#bfcp_floorid{streams = Ss}.
+
+-spec parse(binary()) -> parse_result().
+parse(Bin) ->
+    do_parse_bfcp_floorid(Bin).
+
+-spec assemble(bfcp_floorid()) -> iolist().
+assemble(BF) ->
+    assemble_bfcp_floorid(BF).
+
+-spec assemble_bin(bfcp_floorid()) -> binary().
+assemble_bin(BF) ->
+    iolist_to_binary(assemble(BF)).
+
+%%%===================================================================
+%%% Internal implementation
+%%%===================================================================
+-define(sp, " ").
+
+%% https://tools.ietf.org/rfc/rfc8856.html#name-sdp-floorid-attribute
+%%
+%% floor-id = 1*DIGIT SP "mstrm:" token *(SP token)
+%% DIGIT = <DIGIT as defined in [RFC5234]>
+%% token = <token as defined in [RFC8866]>
+%%
+-spec do_parse_bfcp_floorid(binary()) -> parse_result().
+do_parse_bfcp_floorid(Rest) ->
+    Parsers = [fun ersip_parser_aux:parse_non_neg_int/1,
+               fun parse_mstrm/1
+              ],
+    case ersip_parser_aux:parse_all(Rest, Parsers) of
+        {ok, [ID, Streams], Rest1} when ID < 65536 ->
+            BF = #bfcp_floorid{id = ID, streams = Streams},
+            {ok, BF, Rest1};
+        {ok, [ID|_], _} ->
+            {error, {invalid_bfcp_floorid, {invalid_id, ID}}};
+        {error, Reason} ->
+            {error, {invalid_bfcp_floorid, Reason}}
+    end.
+
+-spec assemble_bfcp_floorid(bfcp_floorid()) -> iolist().
+assemble_bfcp_floorid(#bfcp_floorid{
+                         id = I,
+                         streams = [_|_] = Ss}) ->
+    [integer_to_binary(I), ?sp,
+     "mstrm:", lists:join(?sp, Ss)].
+
+-spec parse_mstrm(binary()) -> parse_result(streams()).
+parse_mstrm(<<?sp, "mstrm:", Rest/binary>>) ->
+    parse_streams(Rest);
+%% For backward compatibility with RFC4583
+parse_mstrm(<<?sp, "m-stream:", Rest/binary>>) ->
+    parse_streams(Rest);
+parse_mstrm(Bin) ->
+    {error, {invalid_mstrm, Bin}}.
+
+%% token *(SP token)
+-spec parse_streams(binary()) -> parse_result(streams()).
+parse_streams(Bin) ->
+    case ersip_parser_aux:token_list(Bin, lws) of
+        {ok, Streams, <<>>} ->
+            {ok, Streams, <<>>};
+        _ ->
+            {error, {invalid_mstrm, Bin}}
+    end.

--- a/test/sdp/media/ersip_sdp_bfcp_floorctrl_test.erl
+++ b/test/sdp/media/ersip_sdp_bfcp_floorctrl_test.erl
@@ -1,0 +1,57 @@
+%%
+%% Copyright (c) 2021 Dmitry Poroh
+%% All rights reserved.
+%% Distributed under the terms of the MIT License. See the LICENSE file.
+%%
+%% SDP media BFCP 'floorctrl' attribute
+%%
+
+-module(ersip_sdp_bfcp_floorctrl_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(ersip_sdp_bfcp_floorctrl,
+        [new/2,
+         client/1,
+         server/1,
+         set_client/2,
+         set_server/2,
+         parse/1,
+         assemble_bin/1
+        ]).
+
+%%%===================================================================
+%%% Cases
+%%%===================================================================
+parse_test() ->
+    {ok, BF1, <<>>} = parse(<<"c-only">>),
+    ?assertEqual(true, client(BF1)),
+    ?assertEqual(false, server(BF1)),
+    {ok, BF2, <<>>} = parse(<<"s-only">>),
+    ?assertEqual(false, client(BF2)),
+    ?assertEqual(true, server(BF2)),
+    {ok, BF3, <<>>} = parse(<<"s-only c-only">>),
+    {ok, BF3, <<>>} = parse(<<"c-only s-only">>),
+    {ok, BF3, <<>>} = parse(<<"c-s">>),
+    ?assertEqual(true, client(BF3)),
+    ?assertEqual(true, server(BF3)).
+
+parse_error_test() ->
+    lists:foreach(
+      fun(Bin) ->
+              ?assertMatch({error, {invalid_bfcp_floorctrl, _}},
+                           parse(Bin))
+      end,
+      [<<>>,
+       <<" ">>,
+       <<" c-only">>,
+       <<"c-only ">>,
+       <<"foo">>]).
+
+assemble_test() ->
+    BF = new(true, true),
+    ?assertEqual(<<"s-only c-only">>, assemble_bin(BF)),
+    BF1 = set_client(false, BF),
+    ?assertEqual(<<"s-only">>, assemble_bin(BF1)),
+    BF2 = set_server(false, BF),
+    ?assertEqual(<<"c-only">>, assemble_bin(BF2)).

--- a/test/sdp/media/ersip_sdp_bfcp_floorid_test.erl
+++ b/test/sdp/media/ersip_sdp_bfcp_floorid_test.erl
@@ -1,0 +1,53 @@
+%%
+%% Copyright (c) 2021 Dmitry Poroh
+%% All rights reserved.
+%% Distributed under the terms of the MIT License. See the LICENSE file.
+%%
+%% SDP media BFCP 'floorid' attribute
+%%
+
+-module(ersip_sdp_bfcp_floorid_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(ersip_sdp_bfcp_floorid,
+        [new/2,
+         id/1,
+         streams/1,
+         set_id/2,
+         set_streams/2,
+         parse/1,
+         assemble_bin/1]).
+
+%%%===================================================================
+%%% Cases
+%%%===================================================================
+parse_test() ->
+    {ok, BF1, <<>>} = parse(<<"123 mstrm:stream-1 stream-2">>),
+    ?assertEqual(123, id(BF1)),
+    ?assertEqual([<<"stream-1">>, <<"stream-2">>], streams(BF1)),
+    {ok, BF2, <<>>} = parse(<<"65535 m-stream:stream-1 stream-2">>),
+    ?assertEqual(65535, id(BF2)),
+    ?assertEqual([<<"stream-1">>, <<"stream-2">>], streams(BF2)),
+    {ok, BF3, <<>>} = parse(<<"0 m-stream:stream-1">>),
+    ?assertEqual(0, id(BF3)),
+    ?assertEqual([<<"stream-1">>], streams(BF3)).
+
+parse_error_test() ->
+    lists:foreach(
+      fun(Bin) ->
+              ?assertMatch({error, {invalid_bfcp_floorid, _}},
+                           parse(Bin))
+      end,
+      [<<"s mstrm:stream-1">>,
+       <<"-2 mstrm:stream-1">>,
+       <<"65536 mstrm:stream-1">>,
+       <<"1 mstrm:">>,
+       <<"1 foo:stream-1">>]).
+
+assemble_test() ->
+    BF1 = new(5, [<<"stream-1">>, <<"stream-2">>]),
+    BF2 = set_id(10, BF1),
+    BF3 = set_streams([<<"stream-2">>, <<"stream-1">>], BF2),
+    ?assertEqual(<<"10 mstrm:stream-2 stream-1">>,
+                 assemble_bin(BF3)).


### PR DESCRIPTION
Parsers for two SDP media attributes have been added: 'floorctrl' and 'floorid'.