### PR TITLE
Make it possible to construct SDP media from scratch

### DIFF
--- a/src/sdp/ersip_sdp_bandwidth.erl
+++ b/src/sdp/ersip_sdp_bandwidth.erl
@@ -8,6 +8,7 @@
 
 -module(ersip_sdp_bandwidth).
 
+-export([new/0]).
 -export([tias/1,
          ct/1,
          as/1,
@@ -33,6 +34,10 @@
 %%%===================================================================
 %%% API
 %%%===================================================================
+
+-spec new() -> bandwidth().
+new() ->
+    {bandwidth, []}.
 
 -spec tias(bandwidth()) -> non_neg_integer() | undefined.
 tias({bandwidth, BWList}) ->
@@ -128,5 +133,3 @@ bw_type_to_binary(tias) ->
     <<"TIAS">>;
 bw_type_to_binary({bw_type, T}) ->
     T.
-
-

--- a/src/sdp/ersip_sdp_conn.erl
+++ b/src/sdp/ersip_sdp_conn.erl
@@ -8,6 +8,8 @@
 
 -module(ersip_sdp_conn).
 
+-export([new/1,
+         new/3]).
 -export([addr/1,
          set_addr/2,
          ttl/1,
@@ -32,6 +34,15 @@
 %%%===================================================================
 %%% API
 %%%===================================================================
+
+-spec new(ersip_sdp_addr:addr()) -> conn().
+new(Addr) ->
+    new(Addr, undefined, 1).
+
+-spec new(ersip_sdp_addr:addr(),
+          non_neg_integer() | undefined, non_neg_integer()) -> conn().
+new(Addr, TTL, NumAddrs) ->
+    #conn{addr = Addr, ttl = TTL, num_addrs = NumAddrs}.
 
 -spec addr(conn()) -> ersip_sdp_addr:addr().
 addr(#conn{addr = Addr}) ->
@@ -197,5 +208,3 @@ is_ip6_multicast({ip6, {A, _, _, _,  _, _, _, _}}) when A >= 16#FF00, A =< 16#FF
     true;
 is_ip6_multicast(_) ->
     false.
-
-

--- a/src/sdp/ersip_sdp_media.erl
+++ b/src/sdp/ersip_sdp_media.erl
@@ -8,10 +8,17 @@
 
 -module(ersip_sdp_media).
 
+-export([new/4,
+         new/5
+        ]).
 -export([type/1,
+         set_type/2,
          port/1,
+         set_port/2,
          port_num/1,
+         set_port_num/2,
          protocol/1,
+         set_protocol/2,
          formats/1,
          set_formats/2,
          conn/1,
@@ -52,29 +59,61 @@
 %%% API
 %%%===================================================================
 
+-spec new(media_type(), inet:port_number(),
+          nonempty_list(binary()), nonempty_list(binary())) -> media().
+new(T, Port, Protocol, FMTS) ->
+    new(T, Port, Protocol, FMTS, 1).
+
+-spec new(media_type(), inet:port_number(),
+          nonempty_list(binary()), nonempty_list(binary()),
+          non_neg_integer()) -> media().
+new(T, Port, Protocol, FMTS, PN) ->
+    #media{type = T,
+           port = Port,
+           port_num = PN,
+           protocol = Protocol,
+           fmts = FMTS,
+           bandwidth = ersip_sdp_bandwidth:new()}.
+
 -spec type(media()) -> binary().
 type(#media{type = T}) ->
     T.
+
+-spec set_type(media_type(), media()) -> media().
+set_type(T, #media{} = Media) ->
+    Media#media{type = T}.
 
 -spec port(media()) -> inet:port_number().
 port(#media{port = P}) ->
     P.
 
+-spec set_port(inet:port_number(), media()) -> media().
+set_port(Port, #media{} = Media) ->
+    Media#media{port = Port}.
+
 -spec port_num(media()) -> non_neg_integer() | undefined.
 port_num(#media{port_num = PN}) ->
     PN.
+
+-spec set_port_num(non_neg_integer() | undefined, media()) -> media().
+set_port_num(PN, #media{} = Media) ->
+    Media#media{port_num = PN}.
 
 -spec protocol(media()) -> nonempty_list(binary()).
 protocol(#media{protocol = P}) ->
     P.
 
--spec formats(media()) -> [binary()].
+-spec set_protocol(nonempty_list(binary()), media()) -> media().
+set_protocol(P, #media{} = Media) ->
+    Media#media{protocol = P}.
+
+-spec formats(media()) -> nonempty_list(binary()).
 formats(#media{fmts = FMTS}) ->
     FMTS.
 
 -spec set_formats([binary()], media()) -> media().
 set_formats(FMTS, #media{} = Media) ->
-     Media#media{fmts = FMTS}.    
+     Media#media{fmts = FMTS}.
 
 -spec conn(media()) -> ersip_sdp_conn:conn() | undefined.
 conn(#media{conn = Conn}) ->
@@ -226,4 +265,3 @@ do_parse_fmts(Bin, Acc) ->
         _ ->
             {ok, lists:reverse(Acc), Bin}
     end.
-

--- a/test/sdp/ersip_sdp_media_test.erl
+++ b/test/sdp/ersip_sdp_media_test.erl
@@ -51,6 +51,18 @@ set_conn_test() ->
     ?assertEqual(ExpectedSDP, ResultSDP),
     ok.
 
+constructor_test() ->
+    Conn = ersip_sdp_conn:new({ip4, {127, 0, 0, 1}}),
+    Media1 = ersip_sdp_media:new(<<"audio">>, 49170, [<<"RTP">>, <<"AVP">>], [<<"0">>]),
+    assemble_parse([Media1]),
+    Media2 = ersip_sdp_media:set_type(<<"video">>, Media1),
+    Media3 = ersip_sdp_media:set_port(50000, Media2),
+    Media4 = ersip_sdp_media:set_port_num(5, Media3),
+    Media5 = ersip_sdp_media:set_protocol([<<"FOO">>, <<"BAR">>, <<"BAZ">>], Media4),
+    Media6 = ersip_sdp_media:set_formats([<<"1">>, <<"2">>, <<"3">>], Media5),
+    Media7 = ersip_sdp_media:set_conn(Conn, Media6),
+    assemble_parse([Media7]).
+
 %%%===================================================================
 %%% Helpers
 %%%===================================================================
@@ -62,3 +74,7 @@ parse(Bin) ->
         {error, _} = Error ->
             Error
     end.
+
+assemble_parse(Medias) ->
+    Bin = iolist_to_binary(ersip_sdp_media:assemble(Medias)),
+    ?assertEqual({ok, Medias}, parse(Bin)).


### PR DESCRIPTION
The title is pretty much self explanatory: now media element can be initialized and filled out without going though the parsing process.