### PR TITLE
UAS: Adding fix for option tag problem with multiple tags in different order (includes tests)

### DIFF
--- a/src/ersip_uas.erl
+++ b/src/ersip_uas.erl
@@ -216,12 +216,13 @@ make_unsupported_scheme(SipMsg, Options, Scheme) ->
       Supported   :: ersip_hdr_opttag_list:option_tag_list(),
       Unsupported :: ersip_hdr_opttag_list:option_tag_list().
 check_supported(Required, Supported) ->
-    Intersect = ersip_hdr_opttag_list:intersect(Required, Supported),
-    case Intersect =:= Required of
+    EmptyList = ersip_hdr_opttag_list:from_list([]),
+    Unsupported = ersip_hdr_opttag_list:subtract(Required, Supported),
+    case Unsupported =:= EmptyList of
         true ->
             all_supported;
         false ->
-            ersip_hdr_opttag_list:subtract(Required, Supported)
+            Unsupported
     end.
 
 -spec check_sip_scheme(ersip_uri:scheme()) -> boolean().

--- a/test/ersip_uas_test.erl
+++ b/test/ersip_uas_test.erl
@@ -129,6 +129,23 @@ extension_is_supported_test() ->
     ?assertMatch({process, _}, ProcessResult),
     ok.
 
+extension_is_supported_multiple_order_test() ->
+    Supported = ersip_hdr_opttag_list:from_list([ersip_option_tag:make(<<"gin">>),
+                                                 ersip_option_tag:make(<<"gruu">>)
+                                                ]),
+    Options = #{supported => Supported
+               },
+    REGISTERSipMsgGinGRUU = register_request_gin_gruu(make_default_source()),
+    ProcessResult = ersip_uas:process_request(REGISTERSipMsgGinGRUU, allowed_methods(), Options),
+    ?assertMatch({process, _}, ProcessResult),
+    Supported2 = ersip_hdr_opttag_list:from_list([ersip_option_tag:make(<<"gruu">>),
+                                                  ersip_option_tag:make(<<"gin">>)
+                                                 ]),
+    Options2 = #{supported => Supported2
+                },
+    ProcessResult2 = ersip_uas:process_request(REGISTERSipMsgGinGRUU, allowed_methods(), Options2),
+    ?assertMatch({process, _}, ProcessResult2),
+    ok.
 
 %%%===================================================================
 %%% Helpers


### PR DESCRIPTION
During testing with UAS I found a problem checking the option tags in Require header: Depending on the order, the check failed. 

I added a test case to reproduce the problem and also a fix.